### PR TITLE
Update solus.php

### DIFF
--- a/solus.php
+++ b/solus.php
@@ -69,7 +69,7 @@ class Solus
         $response = curl_exec($ch);
 
         // error handling
-        if($response ==== false)
+        if($response === false)
         	throw new Exception("Curl error: " . curl_error($ch));
 
         // cleanup


### PR DESCRIPTION
Got Following error:

Parse error: syntax error, unexpected '=' in C:\xampp\htdocs\php-solusvm-api-master\solus.php on line 72

Solfed by changing from "====" to "===" //http://stackoverflow.com/questions/589549/php-vs-operator
